### PR TITLE
Fix various typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com/) and
   - New **Most of Video Advanced now working** 
     Color / HDR tab now fully functional. Standards / Field tab now fully functional. DC, Qmin & Qmax moved to DepPage until I can map it out in a more sensible manner.
   - Fixed bug where default factory always showed the first item in the list (if not set) but then saving Globals would make that first item the default. Fixed by forcing a blank field in the first register.
-  - Added button to select the Factories directory intead of manually typing it in.
+  - Added button to select the Factories directory instead of manually typing it in.
 
 ## [1.1.27-dev] - 2025-09-16
 
@@ -180,7 +180,7 @@ This project loosely follows [Keep a Changelog](https://keepachangelog.com/) and
 ## [1.1.1] - 2025-08-28
 
 ### Added
-- **Factory Tools Updated**: Now includes batch import/export as both flat files or zipped. Local paths and filename keys within factories are removed automatically on export. If you need to retain these keys for in house use, just copy the needed factory file(s) to the new location or use the Backup feature. Import/Export is meant to used for sharing factories publically on the Internet. Not for backing up.
+- **Factory Tools Updated**: Now includes batch import/export as both flat files or zipped. Local paths and filename keys within factories are removed automatically on export. If you need to retain these keys for in house use, just copy the needed factory file(s) to the new location or use the Backup feature. Import/Export is meant to used for sharing factories publicly on the Internet. Not for backing up.
 - **UI updates**
 - **Menu**: Added Custom menu which contains "Add Factory to Stream Table" or use CTRL+INS. This simplifies having to select a Factory on the Builder tab, then click to the Streaming tab and click "Add Stream" there. Just use CTRL+INS, click the next streaming factory, repeat. Builds the list without changing tabs. (Largely untested and Experimental)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 **FreeFactory** is a powerful, user-friendly media conversion system designed for both casual users and broadcast professionals. Originally developed for in-house use at a television station by a broadcast engineer with 40 years of experience, it has evolved from a set of BASH scripts into a full-featured Python3 application with a Qt6 interface.
 
-While **FreeFactory** is designed to make using FFmpeg easier, it supports nearly EVERY FFmpeg option available making FreeFactory the most capible front end for FFmpeg in existence today. While we attempt to hide options that are not compatible with each other from being selected, it is and will be an ongoing process as FFmpeg is a most complicated project. Most common options are currently supported. We thrive to be the closest GUI to an (un)offical GUI as possible, which does not exist.
+While **FreeFactory** is designed to make using FFmpeg easier, it supports nearly EVERY FFmpeg option available making FreeFactory the most capable front end for FFmpeg in existence today. While we attempt to hide options that are not compatible with each other from being selected, it is and will be an ongoing process as FFmpeg is a most complicated project. Most common options are currently supported. We thrive to be the closest GUI to an (un)official GUI as possible, which does not exist.
 
 **FreeFactory** simplifies complex encoding workflows into reusable, sharable *Factories*. While FFmpeg is incredibly powerful, its syntax can be intimidating — **FreeFactory** makes it all accessible without sacrificing any advanced capability.
 

--- a/bin/FreeFactory-tabs.ui
+++ b/bin/FreeFactory-tabs.ui
@@ -2122,7 +2122,7 @@ Ensures strict frame pacing by duplicating or dropping frames as needed.
           </font>
          </property>
          <property name="toolTip">
-          <string>Add Specific video tags. Adds -tag:v to cmmand line.
+          <string>Add Specific video tags. Adds -tag:v to command line.
 ie. For Apple mobile device compatibility, add hvc1.</string>
          </property>
          <property name="editable">
@@ -2165,7 +2165,7 @@ ie. For Apple mobile device compatibility, add hvc1.</string>
           </font>
          </property>
          <property name="toolTip">
-          <string>Add Specific video tags. Adds -tag:v to cmmand line.</string>
+          <string>Add Specific video tags. Adds -tag:v to command line.</string>
          </property>
          <property name="text">
           <string>Tags</string>
@@ -7928,7 +7928,7 @@ Should be on when streaming files</string>
       </property>
       <property name="toolTip">
        <string>Choose Streaming/Record Operational Mode: Off, Stream, Record only, or both.
-When Off, all widgets below are inaccessable.</string>
+When Off, all widgets below are inaccessible.</string>
       </property>
       <item>
        <property name="text">
@@ -8731,9 +8731,9 @@ or Factory Testing</string>
 
 - All files dropped here will use the selected Factory. You cannot yet mix different Factories for batch processing. We may add this in the future.
 
-- If you chage the Factory on the Builder tab while this is running, all unprocessed items will revert to the currently selected Factory and will most likely fail.
+- If you change the Factory on the Builder tab while this is running, all unprocessed items will revert to the currently selected Factory and will most likely fail.
 
-- If you need parallel processing and have the robust hardware to handle it, it is highly recommened you use the FreeFactory service instead. </string>
+- If you need parallel processing and have the robust hardware to handle it, it is highly recommended you use the FreeFactory service instead. </string>
       </property>
      </widget>
     </widget>

--- a/bin/FreeFactoryConversion.tcl
+++ b/bin/FreeFactoryConversion.tcl
@@ -41,7 +41,7 @@ exec tclsh "$0" "$@"
 
 # 2025-08-09
 # Added MANUALOPTIONSINPUT
-# Added check for NVENC availibility
+# Added check for NVENC availability
 
 # 2025-08-15
 # Added VIDEOFILTERS (-vf) and AUDIOFILTERS (-af)

--- a/bin/main.py
+++ b/bin/main.py
@@ -589,13 +589,13 @@ class FreeFactoryApp(QMainWindow):
         self._refresh_video_profiles()  # initial populate from current codec
         self.VideoProfile.setAttribute(Qt.WidgetAttribute.WA_AlwaysShowToolTips, True)
 
-        # Add Support for Multiple Ouputs
+        # Add Support for Multiple Outputs
         assert hasattr(self, "checkMultiOutput"), "QCheckBox 'checkMultiOutput' not found"
         self.checkMultiOutput.toggled.connect(self.update_output_ui_state)
         self.update_output_ui_state()
        
         
-        # Intialize flags builders
+        # Initialize flags builders
         self._init_flags_builders()
 
     def _init_flags_builders(self):
@@ -689,7 +689,7 @@ class FreeFactoryApp(QMainWindow):
     def closeEvent(self, event):
         self._is_closing = True
 
-        # UI-managed activity only (doe NOT touch FreeFactoryConversion.py processes)
+        # UI-managed activity only (does NOT touch FreeFactoryConversion.py processes)
         active_threads = list(getattr(self, "active_threads", []))
         has_threads = any(getattr(t, "isRunning", lambda: False)() for t, _ in active_threads)
         has_streams = bool(getattr(self, "active_streams_by_row", {}))
@@ -1125,7 +1125,7 @@ class FreeFactoryApp(QMainWindow):
 # --- 4) Codec / copy-lock mechanics ------------------------------------------
     # ============================
     #     Copy Codec Handlers 
-    #   Ghosts releated widgets 
+    #   Ghosts related widgets 
     #   when codec "copy" is selected
     # ============================
     def _apply_group_copy_lock(self, names: list[str], *, is_copy: bool, clear_on_disable: bool):

--- a/bin/main_ui_cleanup.py
+++ b/bin/main_ui_cleanup.py
@@ -589,13 +589,13 @@ class FreeFactoryApp(QMainWindow):
         self._refresh_video_profiles()  # initial populate from current codec
         self.VideoProfile.setAttribute(Qt.WidgetAttribute.WA_AlwaysShowToolTips, True)
 
-        # Add Support for Multiple Ouputs
+        # Add Support for Multiple Outputs
         assert hasattr(self, "checkMultiOutput"), "QCheckBox 'checkMultiOutput' not found"
         self.checkMultiOutput.toggled.connect(self.update_output_ui_state)
         self.update_output_ui_state()
        
         
-        # Intialize flags builders
+        # Initialize flags builders
         self._init_flags_builders()
 
     def _init_flags_builders(self):
@@ -689,7 +689,7 @@ class FreeFactoryApp(QMainWindow):
     def closeEvent(self, event):
         self._is_closing = True
 
-        # UI-managed activity only (doe NOT touch FreeFactoryConversion.py processes)
+        # UI-managed activity only (does NOT touch FreeFactoryConversion.py processes)
         active_threads = list(getattr(self, "active_threads", []))
         has_threads = any(getattr(t, "isRunning", lambda: False)() for t, _ in active_threads)
         has_streams = bool(getattr(self, "active_streams_by_row", {}))
@@ -1125,7 +1125,7 @@ class FreeFactoryApp(QMainWindow):
 # --- 4) Codec / copy-lock mechanics ------------------------------------------
     # ============================
     #     Copy Codec Handlers 
-    #   Ghosts releated widgets 
+    #   Ghosts related widgets 
     #   when codec "copy" is selected
     # ============================
     def _apply_group_copy_lock(self, names: list[str], *, is_copy: bool, clear_on_disable: bool):

--- a/database/readme.txt
+++ b/database/readme.txt
@@ -4,13 +4,13 @@ In the future, it is hoped this can also be used to create a dynamic UI by only 
 
 Presently there are seven python scripts used to create this database. I will include those here at some point. Once they are more refined. They can be used to create a new database completely based on the version of the FFmpeg you have installed on your system.
 
-As I am not normally a database administrator, I am sure there are many ways to make this much more efficient and much better. Database experts welcomed to offer improvments, please.
+As I am not normally a database administrator, I am sure there are many ways to make this much more efficient and much better. Database experts welcomed to offer improvements, please.
 
 
 FFmpeg Database tools descriptions:
 These scripts will use YOUR installed version FFmpeg to build the database. There is no guarantee these scripts will work with your version. These were written for FFmpeg 7.1.1. Make a backup of the existing .db file before attempting this. 
 
-rebuild_database.sh: This will DELETE ffmpeg_options.db and run the following python scipts in the following order:
+rebuild_database.sh: This will DELETE ffmpeg_options.db and run the following python scripts in the following order:
 
 - ffmpeg_db_builder.py --mode rebuild
 This will rebuild the database in a basic state and creates and populates the following tables: bitstream_filters, codecs, filters, muxers, pixel_formats


### PR DESCRIPTION
Fixes various user-facing and non-user-facing typos.

Found via `codespell -S "./third_party"`